### PR TITLE
fix: docker image registry

### DIFF
--- a/rag/values.yaml
+++ b/rag/values.yaml
@@ -15,7 +15,7 @@ backend:
   replicaCount: 1
 
   image:
-    repository: ghcr.io/stackitcloud
+    repository: ghcr.io/stackitcloud/rag-template﻿
     name: rag-backend
     pullPolicy: Always
     tag: "v1.0.0"
@@ -153,7 +153,7 @@ frontend:
   name: frontend
   replicaCount: 1
   image:
-    repository: ghcr.io/stackitcloud
+    repository: ghcr.io/stackitcloud/rag-template
     name: frontend
     pullPolicy: Always
     tag: "v1.0.0"
@@ -194,7 +194,7 @@ adminBackend:
   name: admin-backend
 
   image:
-    repository: ghcr.io/stackitcloud
+    repository: ghcr.io/stackitcloud/rag-template
     name: admin-backend
     pullPolicy: Always
     tag: "v1.0.0"
@@ -280,7 +280,7 @@ extractor:
   replicaCount: 1
   name: extractor
   image:
-    repository: ghcr.io/stackitcloud
+    repository: ghcr.io/stackitcloud/rag-template
     name: document-extractor
     pullPolicy: Always
     tag: "v1.0.0"
@@ -328,7 +328,7 @@ adminFrontend:
   name: admin-frontend
   replicaCount: 1
   image:
-    repository: ghcr.io/stackitcloud
+    repository: ghcr.io/stackitcloud/rag-template
     name: admin-frontend
     pullPolicy: Always
     tag: "v1.0.0"


### PR DESCRIPTION
Adds the missing "rag-template" suffix in the repository path
