### PR TITLE
chore: fix default values

### DIFF
--- a/rag/values.yaml
+++ b/rag/values.yaml
@@ -380,7 +380,7 @@ shared:
   secrets:
     s3:
       accessKey: "admin"
-      secretKey: "password"
+      secretKey: "adminpassword"
     usecase:
 
 


### PR DESCRIPTION
Changes the default S3 secretkey to be the same that is set as a default for the minio.