### PR TITLE
refactor: remove confluence loader configuration and related secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/cr-secret.yaml
 **/customer-values.yaml
-
+auth
+*\-values.yaml
 */terraform.tfstate
 */Chart.lock
 *.tgz

--- a/rag/templates/_admin_backend_and_extractor_helpers.tpl
+++ b/rag/templates/_admin_backend_and_extractor_helpers.tpl
@@ -15,10 +15,6 @@
 {{- printf "%s-stackit-vllm-secret" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "secret.confluenceLoaderName" -}}
-{{- printf "%s-confluence-loader-secret" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
 # configmaps
 {{- define "configmap.s3Name" -}}
 {{- printf "%s-s3-configmap" .Release.Name | trunc 63 | trimSuffix "-" -}}
@@ -70,10 +66,6 @@
 
 {{- define "configmap.stackitVllmName" -}}
 {{- printf "%s-stackit-vllm-configmap" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{- define "configmap.confluenceLoaderName" -}}
-{{- printf "%s-confluence-loader-configmap" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 # image

--- a/rag/templates/admin-backend/configmap.yaml
+++ b/rag/templates/admin-backend/configmap.yaml
@@ -28,15 +28,6 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "configmap.confluenceLoaderName" . }}
-data:
-  {{- range $key, $value := .Values.adminBackend.envs.confluenceLoader }}
-  {{ $key }}: {{ $value | quote }}
-  {{- end }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: {{ template "configmap.keyValueStoreName" . }}
 data:
   {{- range $key, $value := .Values.adminBackend.envs.keyValueStore }}

--- a/rag/templates/admin-backend/deployment.yaml
+++ b/rag/templates/admin-backend/deployment.yaml
@@ -103,8 +103,6 @@ spec:
           - configMapRef:
               name: {{ template "configmap.pdfextractorName" . }}
           - configMapRef:
-              name: {{ template "configmap.confluenceLoaderName" . }}
-          - configMapRef:
               name: {{ template "configmap.keyValueStoreName" . }}
           - secretRef:
               name: {{ template "secret.langfuseName" . }}
@@ -114,8 +112,6 @@ spec:
               name: {{ template "secret.s3Name" . }}
           - secretRef:
               name: {{ template "secret.stackitVllmName" . }}
-          - secretRef:
-              name: {{ template "secret.confluenceLoaderName" . }}
         env:
           - name: PYTHONPATH
             value: {{ .Values.adminBackend.pythonPathEnv.PYTHONPATH }}

--- a/rag/templates/admin-backend/secrets.yaml
+++ b/rag/templates/admin-backend/secrets.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ template "secret.confluenceLoaderName" . }}
-type: Opaque
-data:
-  CONFLUENCE_TOKEN: {{ .Values.adminBackend.secrets.confluenceLoader.token | b64enc }}

--- a/rag/values.yaml
+++ b/rag/values.yaml
@@ -261,17 +261,9 @@ adminBackend:
     chunker:
       CHUNKER_MAX_SIZE: 1000
       CHUNKER_OVERLAP: 300
-    confluenceLoader:
-      CONFLUENCE_URL: ""
-      CONFLUENCE_SPACE_KEY: ""
-      CONFLUENCE_DOCUMENT_NAME: ""
     keyValueStore:
       USECASE_KEYVALUE_PORT: 6379
       USECASE_KEYVALUE_HOST: "rag-keydb"
-
-  secrets:
-    confluenceLoader:
-      token: ""
 
 extractor:
   replicaCount: 1


### PR DESCRIPTION
This pull request removes all references to the `confluenceLoader` configuration, including its associated ConfigMap, Secret, and environment variables, simplifying the configuration and deployment files.

### Removal of `confluenceLoader` configuration:

* Deleted the `confluenceLoader` ConfigMap definition and its associated data from `rag/templates/admin-backend/configmap.yaml`.
* Removed the `confluenceLoader` Secret definition from `rag/templates/admin-backend/secrets.yaml`.
* Eliminated the `confluenceLoader` environment variables and secrets from `rag/values.yaml`.

### Updates to deployment references:

* Removed references to the `confluenceLoader` ConfigMap in `rag/templates/admin-backend/deployment.yaml`.
* Removed references to the `confluenceLoader` Secret in `rag/templates/admin-backend/deployment.yaml`.

### Cleanup of helper templates:

* Deleted the `confluenceLoader` Secret and ConfigMap helper templates from `rag/templates/_admin_backend_and_extractor_helpers.tpl`. 