### PR TITLE
fix: remove conditional basicAuth secret reference from admin deployment

### DIFF
--- a/rag/templates/frontend/admin-deployment.yaml
+++ b/rag/templates/frontend/admin-deployment.yaml
@@ -47,10 +47,8 @@ spec:
         envFrom:
           - configMapRef:
               name: {{ template "configmap.frontendName" . }}
-          {{- if .Values.shared.config.basicAuth.enabled }}
           - secretRef:
               name: "vite-auth"
-          {{- end }}
       {{- if .Values.shared.imagePullSecret }}
       imagePullSecrets:
       - name: {{ .Values.shared.imagePullSecret.name }}


### PR DESCRIPTION
This pull request makes a small adjustment to the `rag/templates/frontend/admin-deployment.yaml` file by removing conditional logic for including the `basicAuth` configuration.