### PR TITLE
feat: provide the chat of the rag by MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 **/cr-secret.yaml
 **/customer-values.yaml
-
+**/mcp.json
 */terraform.tfstate
 */Chart.lock
 *.tgz
@@ -147,3 +147,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+auth

--- a/README.md
+++ b/README.md
@@ -170,8 +170,11 @@ The following values should be adjusted for the deployment:
 
 ```yaml
 backend:
-  secrets:
+  mcp:
+    toolName: ...
+    toolDescription: ...
 
+  secrets:
     basicAuth: ...
     langfuse:
       publicKey: ...
@@ -248,6 +251,8 @@ global:
 ```
 
 > 📝 NOTE: All values containg `...` are placeholders and have to be replaced with real values.
+
+> 📝 NOTE: `backend.mcp.toolName` and `backend.mcp.toolDescription` should be adjusted to reflect the data that is served by the RAG in order to make it easy for the mcp client to use the correct mcp server.
 
 > ⓘ INFO: This deployment comes with multiple options. You can change the `global.config.envs.rag_class_types.RAG_CLASS_TYPE_LLM_TYPE` in `./rag/values.yaml` to one of the following values:
 >

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The documentation is structured as follows:
   - [1.3 KeyDB](#13-keydb)
   - [1.4 Frontend](#14-frontend)
   - [1.5 Backend](#15-backend)
-  - [1.6 Use Case Environment Variables](#16-use-case-environment-variables)
+  - [1.6 MCP Server](#16-mcp-server)
+  - [1.7 Use Case Environment Variables](#17-use-case-environment-variables)
 - [2. Requirements and Setup Instructions](#2-requirements-and-setup-instructions)
   - [2.1 Local setup instructions](#21-local-setup-instructions)
   - [2.2 Production setup instructions](#22-production-setup-instructions)
@@ -25,6 +26,7 @@ This Repository contains the helm chart for the following RAG components:
 - [KeyDB](https://docs.keydb.dev/) (dependency)
 - Frontend
 - Backend
+- MCP Server
 
 > 📝 NOTE: Only the settings you are most likely to adjust are listed here. For all available settings please take a look at the [values.yaml](rag/values.yaml).
 
@@ -44,6 +46,8 @@ features:
   frontend:
     enabled: true
   keydb:
+    enabled: true
+  mcp:
     enabled: true
 ```
 
@@ -199,10 +203,6 @@ The following values should be adjusted for the deployment:
 
 ```yaml
 backend:
-  mcp:
-    toolName: ...
-    toolDescription: ...
-
   secrets:
     # Required: Basic authentication for the backend API
     basicAuth: ... # Set your basic auth credentials
@@ -291,7 +291,44 @@ shared:
 >
 > The same options are also available for the `backend.envs.embedderClassTypes.EMBEDDER_CLASS_TYPE_EMBEDDER_TYPE`.
 
-### 1.6 Use Case Environment Variables
+### 1.6 MCP Server
+
+The MCP (Model Context Protocol) Server runs as a sidecar container alongside the main RAG backend and provides MCP-compatible access to the RAG system. It can be enabled or disabled using the following configuration:
+
+```yaml
+features:
+  mcp:
+    enabled: true # Set to false to disable MCP server
+```
+
+When enabled, the MCP server can be configured with the following values:
+
+```yaml
+backend:
+  mcp:
+    name: "mcp" # Name of the MCP server container
+    port: "8000" # Port on which the MCP server listens (default: 8000)
+    host: "0.0.0.0" # Host address for the MCP server
+    image:
+      repository: ghcr.io/stackitcloud/rag-template
+      name: rag-mcp
+      pullPolicy: Always
+      tag: "v1.0.0"
+```
+
+The MCP server exposes the following endpoints:
+
+- **Development**: Accessible via `/mcp` path through port-forward on port 9090 in Tilt setup
+- **Production**: Accessible via `/mcp` path through the main ingress
+
+> 📝 NOTE: The MCP server provides two main tools:
+>
+> - `chat_simple`: Basic question-answering without conversation history
+> - `chat_with_history`: Advanced chat interface with conversation history and returns structured responses with `answer`, `finish_reason`, and `citations`.
+>
+> For detailed information about MCP server configuration and usage, see the [MCP Server README](../mcp-server/README.md).
+
+### 1.7 Use Case Environment Variables
 
 To add use case specific environment variables, the `usecase` secret and configmap can be used. Adding new environment variables to the `usecase` secret and configmap can be done by adding the following values to the `values.yaml` file:
 

--- a/rag/templates/_backend_helpers.tpl
+++ b/rag/templates/_backend_helpers.tpl
@@ -85,6 +85,9 @@
 {{- printf "%s-chat-history-configmap" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "configmap.mcp" -}}
+{{- printf "%s-mcp-configmap" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 
 # ingress
 {{- define "backend.ingressFullName" -}}
@@ -93,4 +96,8 @@
 
 {{- define "backend.fullImageName" -}}
 {{- printf "%s/%s:%s" .Values.backend.image.repository .Values.backend.image.name .Values.backend.image.tag | trimSuffix ":" | trimSuffix "-" }}
+{{- end -}}
+
+{{- define "mcp.fullImageName" -}}
+{{- printf "%s/%s:%s" .Values.backend.mcp.image.repository .Values.backend.mcp.image.name .Values.backend.mcp.image.tag | trimSuffix ":" | trimSuffix "-" }}
 {{- end -}}

--- a/rag/templates/_backend_helpers.tpl
+++ b/rag/templates/_backend_helpers.tpl
@@ -101,3 +101,37 @@
 {{- define "mcp.fullImageName" -}}
 {{- printf "%s/%s:%s" .Values.backend.mcp.image.repository .Values.backend.mcp.image.name .Values.backend.mcp.image.tag | trimSuffix ":" | trimSuffix "-" }}
 {{- end -}}
+
+
+# Common ingress annotations for backend services
+{{- define "backend.ingress.commonAnnotations" -}}
+{{- if .Values.shared.config.basicAuth.enabled }}
+nginx.ingress.kubernetes.io/auth-type: basic
+nginx.ingress.kubernetes.io/auth-secret: basic-auth
+{{- end }}
+nginx.ingress.kubernetes.io/proxy-body-size: "0"
+nginx.ingress.kubernetes.io/proxy-read-timeout: "6000"
+nginx.ingress.kubernetes.io/enable-cors: "true"
+nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
+nginx.ingress.kubernetes.io/cors-max-age: "100"
+nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, PUT, DELETE, OPTIONS"
+{{- if .Values.shared.config.tls.enabled }}
+nginx.ingress.kubernetes.io/ssl-redirect: "true"
+nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://{{ .Values.backend.ingress.host.name }}, https://admin.{{ .Values.backend.ingress.host.name }}"
+{{- else }}
+nginx.ingress.kubernetes.io/ssl-redirect: "false"
+nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+{{- end }}
+{{- end -}}
+
+# Common ingress spec for backend services
+{{- define "backend.ingress.commonSpec" -}}
+{{- if .Values.shared.config.tls.enabled }}
+tls:
+  - hosts:
+    - {{ .Values.shared.config.tls.host }}
+    secretName: {{ .Values.shared.config.tls.secretName }}
+{{- end }}
+ingressClassName: nginx
+{{- end -}}

--- a/rag/templates/backend/configmap.yaml
+++ b/rag/templates/backend/configmap.yaml
@@ -133,3 +133,14 @@ data:
   {{- range $key, $value := .Values.backend.envs.ollamaEmbedder }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "configmap.mcp" . }}
+data:
+  MCP_PORT: {{ .Values.backend.mcp.port | quote }}
+  MCP_TOOL_NAME: {{ .Values.backend.mcp.toolName }}
+  MCP_TOOL_DESCRIPTION: {{ .Values.backend.mcp.toolDescription }}
+  MCP_NAME: {{  .Values.backend.mcp.name }}
+---

--- a/rag/templates/backend/deployment.yaml
+++ b/rag/templates/backend/deployment.yaml
@@ -40,6 +40,19 @@ spec:
         - name: log-dir
           mountPath: /app/rag-backend/log
       containers:
+      {{- if .Values.backend.mcp.enabled }}        
+      - name: {{ .Values.backend.mcp.name }}
+        image: {{ include "mcp.fullImageName" . }}
+        imagePullPolicy: {{ .Values.backend.mcp.image.pullPolicy }}
+        envFrom:
+          - configMapRef:
+              name: {{ template "configmap.mcp" . }}
+        volumeMounts:
+          - name: config-volume
+            mountPath: /config
+          - name: log-dir
+            mountPath: /app/mcp-server/log
+      {{- end }}
       - name: {{ .Values.backend.name }}
         securityContext:
           allowPrivilegeEscalation: false

--- a/rag/templates/backend/deployment.yaml
+++ b/rag/templates/backend/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - name: log-dir
           mountPath: /app/rag-backend/log
       containers:
-      {{- if .Values.backend.mcp.enabled }}        
+      {{- if .Values.features.mcp.enabled }}
       - name: {{ .Values.backend.mcp.name }}
         image: {{ include "mcp.fullImageName" . }}
         imagePullPolicy: {{ .Values.backend.mcp.image.pullPolicy }}

--- a/rag/templates/backend/ingress.yaml
+++ b/rag/templates/backend/ingress.yaml
@@ -45,11 +45,11 @@ spec:
             service:
               name: {{ $.Values.backend.name }}
               port:
-                number: {{ .Values.backend.ingress.host.port }}                      
+                number: {{ .Values.backend.ingress.host.port }}
 {{- end }}
 ---
 {{- if .Values.backend.ingress.enabled -}}
-{{- if .Values.backend.mcp.enabled }}     
+{{- if .Values.backend.mcp.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -68,7 +68,6 @@ metadata:
     #  more_set_headers "Access-Control-Allow-Origin: $http_origin";
     nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
     nginx.ingress.kubernetes.io/cors-max-age: "100"
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"
     {{- if .Values.shared.config.tls.enabled }}
@@ -89,13 +88,13 @@ spec:
   rules:
   - host: {{ .Values.backend.ingress.host.name }}
     http:
-      paths:             
-        - path: /mcp/(.*)
+      paths:
+        - path: /mcp
           pathType: Prefix
           backend:
             service:
               name: {{ $.Values.backend.name }}
               port:
-                number: {{ .Values.backend.mcp.port }}            
-{{- end }}                          
+                number: {{ .Values.backend.mcp.port }}
+{{- end }}
 {{- end }}

--- a/rag/templates/backend/ingress.yaml
+++ b/rag/templates/backend/ingress.yaml
@@ -10,6 +10,11 @@ metadata:
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "6000"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    #nginx.ingress.kubernetes.io/configuration-snippet: |
+    #  more_set_headers "Access-Control-Allow-Origin: $http_origin";
     nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
     nginx.ingress.kubernetes.io/cors-max-age: "100"
     nginx.ingress.kubernetes.io/enable-cors: "true"
@@ -17,10 +22,10 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /chat/$2
     {{- if .Values.shared.config.tls.enabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "https://{{ .Values.backend.ingress.host.name }}, https://admin.{{ .Values.backend.ingress.host.name }}"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://{{ .Values.backend.ingress.host.name }}, https://admin.{{ .Values.backend.ingress.host.name }}"
     {{- else }}
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "http://{{ .Values.backend.ingress.host.name }}, http://admin.{{ .Values.backend.ingress.host.name }}"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
     {{- end }}
 spec:
   {{- if .Values.shared.config.tls.enabled }}
@@ -40,5 +45,57 @@ spec:
             service:
               name: {{ $.Values.backend.name }}
               port:
-                number: {{ .Values.backend.ingress.host.port }}
+                number: {{ .Values.backend.ingress.host.port }}                      
+{{- end }}
+---
+{{- if .Values.backend.ingress.enabled -}}
+{{- if .Values.backend.mcp.enabled }}     
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp
+  annotations:
+    {{- if .Values.shared.config.basicAuth.enabled }}
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+    {{- end }}
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "6000"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
+    #nginx.ingress.kubernetes.io/configuration-snippet: |
+    #  more_set_headers "Access-Control-Allow-Origin: $http_origin";
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
+    nginx.ingress.kubernetes.io/cors-max-age: "100"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"
+    {{- if .Values.shared.config.tls.enabled }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://{{ .Values.backend.ingress.host.name }}, https://admin.{{ .Values.backend.ingress.host.name }}"
+    {{- else }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
+    {{- end }}
+spec:
+  {{- if .Values.shared.config.tls.enabled }}
+  tls:
+    - hosts:
+      - {{ .Values.shared.config.tls.host }}
+      secretName: {{ .Values.shared.config.tls.secretName }}
+  {{- end }}
+  ingressClassName: nginx
+  rules:
+  - host: {{ .Values.backend.ingress.host.name }}
+    http:
+      paths:             
+        - path: /mcp/(.*)
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ $.Values.backend.name }}
+              port:
+                number: {{ .Values.backend.mcp.port }}            
+{{- end }}                          
 {{- end }}

--- a/rag/templates/backend/ingress.yaml
+++ b/rag/templates/backend/ingress.yaml
@@ -49,7 +49,7 @@ spec:
 {{- end }}
 ---
 {{- if .Values.backend.ingress.enabled -}}
-{{- if .Values.backend.mcp.enabled }}
+{{- if .Values.features.mcp.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/rag/templates/backend/ingress.yaml
+++ b/rag/templates/backend/ingress.yaml
@@ -1,40 +1,14 @@
 {{- if .Values.backend.ingress.enabled -}}
+# Backend Main Ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "backend.ingressFullName" . }}
   annotations:
-    {{- if .Values.shared.config.basicAuth.enabled }}
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: basic-auth
-    {{- end }}
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "6000"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
-    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
-    #nginx.ingress.kubernetes.io/configuration-snippet: |
-    #  more_set_headers "Access-Control-Allow-Origin: $http_origin";
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
-    nginx.ingress.kubernetes.io/cors-max-age: "100"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"
+    {{- include "backend.ingress.commonAnnotations" . | nindent 4 }}
     nginx.ingress.kubernetes.io/rewrite-target: /chat/$2
-    {{- if .Values.shared.config.tls.enabled }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://{{ .Values.backend.ingress.host.name }}, https://admin.{{ .Values.backend.ingress.host.name }}"
-    {{- else }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    {{- end }}
 spec:
-  {{- if .Values.shared.config.tls.enabled }}
-  tls:
-    - hosts:
-      - {{ .Values.shared.config.tls.host }}
-      secretName: {{ .Values.shared.config.tls.secretName }}
-  {{- end }}
-  ingressClassName: nginx
+  {{- include "backend.ingress.commonSpec" . | nindent 2 }}
   rules:
   - host: {{ .Values.backend.ingress.host.name }}
     http:
@@ -48,43 +22,16 @@ spec:
                 number: {{ .Values.backend.ingress.host.port }}
 {{- end }}
 ---
-{{- if .Values.backend.ingress.enabled -}}
-{{- if .Values.features.mcp.enabled }}
+{{- if and .Values.backend.ingress.enabled .Values.features.mcp.enabled }}
+# MCP Ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: mcp
+  name: {{ printf "%s-mcp" (include "backend.ingressFullName" .) }}
   annotations:
-    {{- if .Values.shared.config.basicAuth.enabled }}
-    nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/auth-secret: basic-auth
-    {{- end }}
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "6000"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "PUT, GET, POST, OPTIONS"
-    nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
-    #nginx.ingress.kubernetes.io/configuration-snippet: |
-    #  more_set_headers "Access-Control-Allow-Origin: $http_origin";
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "6000"
-    nginx.ingress.kubernetes.io/cors-max-age: "100"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, POST, DELETE, OPTIONS"
-    {{- if .Values.shared.config.tls.enabled }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "http://localhost:4200, https://{{ .Values.backend.ingress.host.name }}, https://admin.{{ .Values.backend.ingress.host.name }}"
-    {{- else }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "*"
-    {{- end }}
+    {{- include "backend.ingress.commonAnnotations" . | nindent 4 }}
 spec:
-  {{- if .Values.shared.config.tls.enabled }}
-  tls:
-    - hosts:
-      - {{ .Values.shared.config.tls.host }}
-      secretName: {{ .Values.shared.config.tls.secretName }}
-  {{- end }}
-  ingressClassName: nginx
+  {{- include "backend.ingress.commonSpec" . | nindent 2 }}
   rules:
   - host: {{ .Values.backend.ingress.host.name }}
     http:
@@ -96,5 +43,4 @@ spec:
               name: {{ $.Values.backend.name }}
               port:
                 number: {{ .Values.backend.mcp.port }}
-{{- end }}
 {{- end }}

--- a/rag/templates/backend/service.yaml
+++ b/rag/templates/backend/service.yaml
@@ -8,10 +8,10 @@ spec:
   - port: {{ .Values.backend.service.port }}
     name: backend
     targetPort: {{ .Values.backend.service.port }}
-  {{- if .Values.backend.mcp.enabled }}        
+  {{- if .Values.features.mcp.enabled }}
   - port: {{ .Values.backend.mcp.port }}
     targetPort: {{ .Values.backend.mcp.port }}
     name: mcp
-  {{- end }}    
+  {{- end }}
   selector:
     app: {{ .Values.backend.name }}

--- a/rag/templates/backend/service.yaml
+++ b/rag/templates/backend/service.yaml
@@ -6,6 +6,12 @@ spec:
   type: {{ .Values.backend.service.type }}
   ports:
   - port: {{ .Values.backend.service.port }}
+    name: backend
     targetPort: {{ .Values.backend.service.port }}
+  {{- if .Values.backend.mcp.enabled }}        
+  - port: {{ .Values.backend.mcp.port }}
+    targetPort: {{ .Values.backend.mcp.port }}
+    name: mcp
+  {{- end }}    
   selector:
     app: {{ .Values.backend.name }}

--- a/rag/values.yaml
+++ b/rag/values.yaml
@@ -14,10 +14,10 @@ backend:
 
   mcp:
     enabled: true
-    toolDescription: ""
     name: "mcp"
-    toolName: ""
-    port: "8081"
+    port: "8000"
+    toolName: "chat_with_rag"
+    toolDescription: "Chat with the RAG backend system to get answers based on indexed documents"
     image:
       repository: ghcr.io/stackitcloud/rag-template
       name: rag-mcp

--- a/rag/values.yaml
+++ b/rag/values.yaml
@@ -11,15 +11,15 @@ features:
     enabled: true
   keydb:
     enabled: true
+  mcp:
+    enabled: true
 
 backend:
 
   mcp:
-    enabled: true
     name: "mcp"
     port: "8000"
-    toolName: "chat_with_rag"
-    toolDescription: "Chat with the RAG backend system to get answers based on indexed documents"
+    host: "0.0.0.0"
     image:
       repository: ghcr.io/stackitcloud/rag-template
       name: rag-mcp

--- a/rag/values.yaml
+++ b/rag/values.yaml
@@ -11,6 +11,19 @@ features:
     enabled: true
 
 backend:
+
+  mcp:
+    enabled: true
+    toolDescription: ""
+    name: "mcp"
+    toolName: ""
+    port: "8081"
+    image:
+      repository: ghcr.io/stackitcloud/rag-template
+      name: rag-mcp
+      pullPolicy: Always
+      tag: "v1.0.0"
+
   name: backend
   replicaCount: 1
 


### PR DESCRIPTION
This pull request introduces support for a new "MCP" (Model Context Protocol) feature in the backend, including configuration, deployment, and ingress updates. The changes enable the MCP service to run alongside the existing backend service and include updates to YAML templates, configuration files, and ingress rules to support this functionality.

### MCP Feature Integration:

* **Configuration for MCP**: Added MCP-related fields in `values.yaml` for enabling the service, setting its name, port, tool details, and image configuration. (`rag/values.yaml`, [rag/values.yamlR16-R28](diffhunk://#diff-006a29dcae7d31dfae94ba51c79ef927640b623665cb8006b4b57c2503a75660R16-R28))
* **MCP ConfigMap**: Created a new ConfigMap to store MCP-specific environment variables like port, tool name, and description. (`rag/templates/backend/configmap.yaml`, [rag/templates/backend/configmap.yamlR136-R146](diffhunk://#diff-aa3ce9193a08b9a3a43a0290cc1d6e3618ddce4cc5995ef8cac8046514b5ac88R136-R146))
* **MCP Deployment**: Updated the deployment template to conditionally include the MCP container with its image, environment variables, and volume mounts. (`rag/templates/backend/deployment.yaml`, [rag/templates/backend/deployment.yamlR43-R55](diffhunk://#diff-1d8c831389918a130f3c8eea07dadc465260f009621aaf0f4ecc1d2b1ef60f54R43-R55))
* **MCP Service Port**: Added a dedicated service port for MCP in the backend service configuration. (`rag/templates/backend/service.yaml`, [rag/templates/backend/service.yamlR9-R15](diffhunk://#diff-1ff3e9c5e41d9c46be169ba3fc84150d600f5e0e54a872d0d4c05f50ed4cce78R9-R15))

### Ingress Updates:

* **CORS and MCP Ingress Rules**: Enhanced CORS settings and added a new ingress configuration for MCP, including support for basic authentication and TLS. (`rag/templates/backend/ingress.yaml`, [[1]](diffhunk://#diff-fe6097e6cf612e29b2961724e400bc59d5faff2673df8bde54ceaa80475cedadR13-R28) [[2]](diffhunk://#diff-fe6097e6cf612e29b2961724e400bc59d5faff2673df8bde54ceaa80475cedadR50-R100)

### Helm Template Enhancements:

* **Helper Templates for MCP**: Introduced helper templates for MCP ConfigMap and image name generation. (`rag/templates/_backend_helpers.tpl`, [[1]](diffhunk://#diff-5b3669e43f70697cc685c746752d82cfa29d20b8a45af4cb33450c69106cb853R88-R90) [[2]](diffhunk://#diff-5b3669e43f70697cc685c746752d82cfa29d20b8a45af4cb33450c69106cb853R100-R103)

### Documentation:

* **README Update**: Documented the new MCP configuration fields in the deployment instructions. (`README.md`, [README.mdR202-R205](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R202-R205))