### PR TITLE
chore: update image tags to v1.2.0

### DIFF
--- a/rag/values.yaml
+++ b/rag/values.yaml
@@ -24,7 +24,7 @@ backend:
       repository: ghcr.io/stackitcloud/rag-template
       name: rag-mcp
       pullPolicy: Always
-      tag: "v1.0.0"
+      tag: "v1.2.0"
 
   name: backend
   replicaCount: 1
@@ -33,7 +33,7 @@ backend:
     repository: ghcr.io/stackitcloud/rag-template
     name: rag-backend
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v1.2.0"
 
   command:
   - "poetry"
@@ -171,7 +171,7 @@ frontend:
     repository: ghcr.io/stackitcloud/rag-template
     name: frontend
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v1.2.0"
 
   service:
     type: ClusterIP
@@ -207,7 +207,7 @@ adminBackend:
     repository: ghcr.io/stackitcloud/rag-template
     name: admin-backend
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v1.2.0"
 
   command:
   - "poetry"
@@ -287,7 +287,7 @@ extractor:
     repository: ghcr.io/stackitcloud/rag-template
     name: document-extractor
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v1.2.0"
 
   command:
   - "poetry"
@@ -335,7 +335,7 @@ adminFrontend:
     repository: ghcr.io/stackitcloud/rag-template
     name: admin-frontend
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v1.2.0"
 
   service:
     type: ClusterIP


### PR DESCRIPTION
This pull request updates the image tags for various components in the `rag/values.yaml` file to use version `v1.2.0` instead of `v1.0.0`. These changes ensure that the deployment uses the latest version of the images.

Version updates across components:

* [`backend`](diffhunk://#diff-006a29dcae7d31dfae94ba51c79ef927640b623665cb8006b4b57c2503a75660L27-R27): Updated the image tag from `v1.0.0` to `v1.2.0` for `rag-mcp` and `rag-backend`. [[1]](diffhunk://#diff-006a29dcae7d31dfae94ba51c79ef927640b623665cb8006b4b57c2503a75660L27-R27) [[2]](diffhunk://#diff-006a29dcae7d31dfae94ba51c79ef927640b623665cb8006b4b57c2503a75660L36-R36)
* [`frontend`](diffhunk://#diff-006a29dcae7d31dfae94ba51c79ef927640b623665cb8006b4b57c2503a75660L174-R174): Updated the image tag from `v1.0.0` to `v1.2.0`.
* [`adminBackend`](diffhunk://#diff-006a29dcae7d31dfae94ba51c79ef927640b623665cb8006b4b57c2503a75660L210-R210): Updated the image tag from `v1.0.0` to `v1.2.0`.
* [`extractor`](diffhunk://#diff-006a29dcae7d31dfae94ba51c79ef927640b623665cb8006b4b57c2503a75660L290-R290): Updated the image tag from `v1.0.0` to `v1.2.0` for `document-extractor`.
* [`adminFrontend`](diffhunk://#diff-006a29dcae7d31dfae94ba51c79ef927640b623665cb8006b4b57c2503a75660L338-R338): Updated the image tag from `v1.0.0` to `v1.2.0`.